### PR TITLE
feat: add CPFCNPJSerializerField for DRF and wire CPFCNPJValidator into CPFCNPJField

### DIFF
--- a/musa_django_utils/django/fields/br_fields.py
+++ b/musa_django_utils/django/fields/br_fields.py
@@ -1,0 +1,25 @@
+from django.db.models import CharField
+
+from ..validators import CPFCNPJValidator
+
+
+class CPFCNPJField(CharField):
+    description = "Field to store Brazilian CPF or CNPJ numbers"
+
+    def __init__(self, *args, **kwargs):
+        kwargs['max_length'] = 18  # Maximum length for formatted CNPJ
+        super().__init__(*args, **kwargs)
+        self.validators.append(CPFCNPJValidator())
+
+    def to_python(self, value):
+        if value is None:
+            return value
+        # Remove any formatting characters
+        return ''.join(filter(str.isdigit, value))
+
+    def get_prep_value(self, value):
+        value = super().get_prep_value(value)
+        if value is None:
+            return value
+        # Ensure the value is stored without formatting
+        return ''.join(filter(str.isdigit, value))

--- a/musa_django_utils/drf/fields/__init__.py
+++ b/musa_django_utils/drf/fields/__init__.py
@@ -1,2 +1,3 @@
 from .boolean_monthday import *  # noqa
 from .boolean_weekday import *  # noqa
+from .br_fields import *  # noqa

--- a/musa_django_utils/drf/fields/br_fields.py
+++ b/musa_django_utils/drf/fields/br_fields.py
@@ -1,0 +1,15 @@
+import re
+
+from rest_framework import serializers
+
+from musa_django_utils.django.validators import CPFCNPJValidator
+
+
+class CPFCNPJSerializerField(serializers.CharField):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.validators.append(CPFCNPJValidator())
+
+    def to_internal_value(self, data):
+        value = super().to_internal_value(data)
+        return re.sub(r'\D', '', value)


### PR DESCRIPTION
## Summary

- `CPFCNPJField` (model field) agora inclui `CPFCNPJValidator` nos seus validators, garantindo validação matemática de CPF/CNPJ no nível do model
- Novo `CPFCNPJSerializerField` (DRF) que estende `serializers.CharField`:
  - Strip de caracteres não-dígitos em `to_internal_value` (armazena sempre só dígitos)
  - Appenda `CPFCNPJValidator` para validação matemática de CPF/CNPJ
- Exportado via `musa_django_utils.drf.fields`

## Uso

```python
from musa_django_utils.drf.fields import CPFCNPJSerializerField

class MySerializer(serializers.ModelSerializer):
    document = CPFCNPJSerializerField()
```

## Test plan

- [ ] Input com CPF válido formatado (`123.456.789-09`) → armazena `12345678909`
- [ ] Input com CNPJ válido formatado → armazena só dígitos
- [ ] CPF inválido (dígitos verificadores errados) → retorna HTTP 400
- [ ] CNPJ inválido → retorna HTTP 400
- [ ] Documento com comprimento errado → retorna HTTP 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)