### PR TITLE
fix(models): remove blank=True from SoftDeleteAtModel.deleted_at

### DIFF
--- a/musa_django_utils/django/models/soft_delete_at.py
+++ b/musa_django_utils/django/models/soft_delete_at.py
@@ -32,7 +32,7 @@ class SoftDeleteAtQueryset(QuerySet):
 
 
 class SoftDeleteAtModel(Model):
-    deleted_at = DateTimeField(null=True, blank=True, db_index=True)
+    deleted_at = DateTimeField(null=True, db_index=True)
     created_at = DateTimeField(auto_now_add=True)
     updated_at = DateTimeField(auto_now=True)
 


### PR DESCRIPTION
## Summary
- Remove `blank=True` from `SoftDeleteAtModel.deleted_at` — field is `null=True` so `blank` has no effect at DB level; keeping it generates `blank=True` in all downstream migrations

## Test plan
- [ ] Downstream migrations use `DateTimeField(null=True, db_index=True)` without `blank`

🤖 Generated with [Claude Code](https://claude.com/claude-code)